### PR TITLE
The className was excluded for togglable command bar options.

### DIFF
--- a/packages/roosterjs-react-command-bar/lib/components/RoosterCommandBar.tsx
+++ b/packages/roosterjs-react-command-bar/lib/components/RoosterCommandBar.tsx
@@ -160,6 +160,7 @@ export default class RoosterCommandBar extends React.PureComponent<RoosterComman
             return null;
         }
 
+        const { className } = this.props;
         const { formatState } = this.state;
 
         if (commandBarButton.getChecked) {
@@ -167,7 +168,7 @@ export default class RoosterCommandBar extends React.PureComponent<RoosterComman
             commandBarButton.checked = checked;
 
             if (!commandBarButton.isContextMenuItem) {
-                commandBarButton.className = css(RoosterCommandBarButtonRootClassName, 'rooster-command-toggle', { 'is-checked': checked, 'first-level': firstLevel });
+                commandBarButton.className = css(RoosterCommandBarButtonRootClassName, 'rooster-command-toggle', { 'is-checked': checked, 'first-level': firstLevel }, className);
                 commandBarButton['aria-pressed'] = checked; // OF 5.0
             }
         }


### PR DESCRIPTION
@adriantran The passed in class name was excluded in the css for the togglable buttons like bold and italicize, so these buttons weren't able to get the theme classname. I added it in, and Pranav said you should merge this change first and then merge your changes in so there won't be conflicts or anything. 