### PR TITLE
Imported roosterjs 6.19.1 to switch to using clearBlockFormat by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs-react",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "A react component wrapper for roosterjs with more plugins",
   "main": "lib/index.js",
   "repository": {
@@ -26,8 +26,8 @@
     "office-ui-fabric-react": "~5.112.0",
     "react": "~15.3.2",
     "react-dom": "~15.3.2",
-    "roosterjs-editor-plugins": "^6.18.0",
-    "roosterjs-plugin-image-resize": "^6.18.0"
+    "roosterjs-editor-plugins": "^6.19.1",
+    "roosterjs-plugin-image-resize": "^6.19.1"
   },
   "devDependencies": {
     "@types/node": "8.0.50",

--- a/packages/roosterjs-react-command-bar/lib/plugins/RoosterCommandBarPlugin.ts
+++ b/packages/roosterjs-react-command-bar/lib/plugins/RoosterCommandBarPlugin.ts
@@ -1,4 +1,4 @@
-import { toggleBold, toggleBullet, toggleItalic, toggleNumbering, toggleUnderline, clearFormat, toggleHeader } from "roosterjs-editor-api";
+import { clearBlockFormat, clearFormat, toggleBold, toggleBullet, toggleHeader, toggleItalic, toggleNumbering, toggleUnderline } from "roosterjs-editor-api";
 import { Editor, EditorPlugin } from "roosterjs-editor-core";
 import { PluginDomEvent, PluginEvent, PluginEventType } from "roosterjs-editor-types";
 import { NullFunction, Strings, toggleNonCompatBullet, toggleNonCompatNumbering } from "roosterjs-react-common";
@@ -22,6 +22,7 @@ export interface RoosterCommandBarPluginOptions {
     calloutOnDismiss?: (ev?: any) => void;
     onShortcutTriggered?: (command: RoosterShortcutCommands) => void;
     disableListWorkaround?: boolean;
+    useLegacyClearFormat?: boolean;
 }
 
 export default class RoosterCommandBarPlugin implements EditorPlugin, RoosterCommandBarPluginInterface {
@@ -157,8 +158,12 @@ export default class RoosterCommandBarPlugin implements EditorPlugin, RoosterCom
         const editor = this.editor;
 
         this.editor.addUndoSnapshot(() => {
-            clearFormat(editor);
-            toggleHeader(editor, 0);
+            if (this.options.useLegacyClearFormat) {
+                clearFormat(editor);
+                toggleHeader(editor, 0);
+            } else {
+                clearBlockFormat(editor);
+            }
         });
     }
 }


### PR DESCRIPTION
Imported roosterjs 6.19.1 to switch to using clearBlockFormat by default. Also includes multi-line pre text paste into single bug fix.