### PR TITLE
Update package.json to include the repository 

### DIFF
--- a/packages/roosterjs-react-command-bar/package.json
+++ b/packages/roosterjs-react-command-bar/package.json
@@ -6,5 +6,10 @@
     "roosterjs-react-editor": "",
     "roosterjs-react-emoji": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-command-bar"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-common/package.json
+++ b/packages/roosterjs-react-common/package.json
@@ -8,6 +8,11 @@
     "office-ui-fabric-react": ">=5.9.0",
     "react": ">=15.3.2",
     "react-dom": ">=15.3.2"
- },
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-common"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-editor/package.json
+++ b/packages/roosterjs-react-editor/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "roosterjs-react-common": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-editor"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-emoji-resources/package.json
+++ b/packages/roosterjs-react-emoji-resources/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "roosterjs-react-common": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-emoji-resources"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-emoji/package.json
+++ b/packages/roosterjs-react-emoji/package.json
@@ -5,5 +5,10 @@
     "roosterjs-react-common": "",
     "roosterjs-react-emoji-resources": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-emoji"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-pickers/package.json
+++ b/packages/roosterjs-react-pickers/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "roosterjs-react-common": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-pickers"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-ribbon/package.json
+++ b/packages/roosterjs-react-ribbon/package.json
@@ -7,7 +7,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/roosterjs-react.git",
-    "directory": "packages/roosterjs-react-pickers"
+    "directory": "packages/roosterjs-react-ribbon"
   },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react-ribbon/package.json
+++ b/packages/roosterjs-react-ribbon/package.json
@@ -4,5 +4,10 @@
   "dependencies": {
     "roosterjs-react-pickers": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react-pickers"
+  },
   "main": "./lib/index.ts"
 }

--- a/packages/roosterjs-react/package.json
+++ b/packages/roosterjs-react/package.json
@@ -7,5 +7,10 @@
     "roosterjs-react-command-bar": "",
     "roosterjs-react-emoji": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/roosterjs-react.git",
+    "directory": "packages/roosterjs-react"
+  },
   "main": "./lib/index.ts"
 }


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.
 
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
 
If you do not want us to create such PRs against your repositories, please comment on this PR. We will see replies to this pull request.

Published NPM packages with repository information:
* roosterjs-react-ribbon
* roosterjs-react-pickers
* roosterjs-react-emoji-resources
* roosterjs-react-emoji
* roosterjs-react-editor
* roosterjs-react-common
* roosterjs-react-command-bar
* roosterjs-react