### PR TITLE
Set IconButton disabled attribute; Allow for custom IconButton styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roosterjs-react",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "A react component wrapper for roosterjs with more plugins",
   "main": "lib/index.js",
   "repository": {

--- a/packages/roosterjs-react-ribbon/lib/components/Ribbon.tsx
+++ b/packages/roosterjs-react-ribbon/lib/components/Ribbon.tsx
@@ -183,6 +183,7 @@ export default class Ribbon extends React.Component<RibbonProps, RibbonState> {
                 key={name}>
                 <IconButton
                     className={buttonClassName}
+                    styles={this.props.buttonStyle}
                     data-is-focusable={!isDisabled}
                     disabled={isDisabled}
                     title={title}

--- a/packages/roosterjs-react-ribbon/lib/components/Ribbon.tsx
+++ b/packages/roosterjs-react-ribbon/lib/components/Ribbon.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
-import RibbonButton, { RibbonButtonState } from '../schema/RibbonButton';
-import RibbonProps from '../schema/RibbonProps';
-import { createFormatState } from 'roosterjs-react-editor';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
-import { FormatState } from 'roosterjs-editor-types';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
 import { getFormatState } from 'roosterjs-editor-api';
+import { FormatState } from 'roosterjs-editor-types';
+import { createFormatState } from 'roosterjs-react-editor';
+import RibbonButton, { RibbonButtonState } from '../schema/RibbonButton';
+import RibbonProps from '../schema/RibbonProps';
 import { getString } from '../strings/ribbonButtonStrings';
 import * as Buttons from './buttons';
 import * as Styles from './Ribbon.scss.g';
@@ -183,15 +183,16 @@ export default class Ribbon extends React.Component<RibbonProps, RibbonState> {
                 key={name}>
                 <IconButton
                     className={buttonClassName}
-                    data-is-focusable={true}
+                    data-is-focusable={!isDisabled}
+                    disabled={isDisabled}
                     title={title}
                     onClick={!isDisabled && (() => this.onRibbonButton(name))}
                     onDragStart={this.cancelEvent}>
                     {this.props.buttonRenderer ? (
                         this.props.buttonRenderer(name, this.props.isRtl)
                     ) : (
-                            <span>{name}</span>
-                        )}
+                        <span>{name}</span>
+                    )}
                 </IconButton>
             </div>
         );

--- a/packages/roosterjs-react-ribbon/lib/schema/RibbonProps.ts
+++ b/packages/roosterjs-react-ribbon/lib/schema/RibbonProps.ts
@@ -1,6 +1,7 @@
-import RibbonPluginInterface from './RibbonPluginInterface';
-import RibbonButton from './RibbonButton';
+import { IButtonStyles } from 'office-ui-fabric-react';
 import { Strings } from '../strings/ribbonButtonStrings';
+import RibbonButton from './RibbonButton';
+import RibbonPluginInterface from './RibbonPluginInterface';
 
 interface RibbonProps {
     /**
@@ -13,6 +14,11 @@ interface RibbonProps {
      * Default behavior is to render the button name
      */
     buttonRenderer?: (buttonName: string, isRtl: boolean) => JSX.Element;
+
+    /**
+     * A custom set of styles to render the button with
+     */
+    buttonStyle?: IButtonStyles;
 
     /**
      * Minimum count of button to shown in ribbon.


### PR DESCRIPTION
Fixes: https://github.com/microsoft/roosterjs-react/issues/126

Issue: The IconButton doesn't get the disabled attribute set when it's disabled. Instead, only styling is applied.
Fix: Set the disabled attribute and data-is-focusable conditionally.

Issue: A consumer should be able to provide styles for the rendered IconButtons.
Fix: Add a prop to pass along styles from the Ribbon component to the IconButtons.